### PR TITLE
SYC-424

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Ce guide explique comment **s’authentifier**, **explorer la documentation Swagger**, **lister vos équipements** et **récupérer des données brutes**.
 
-**Swagger** : <https://hello-sycon.github.io/sycon-api/>  
+**Swagger** : <https://cloud.sycon.io/swagger-ui/index.html>  
 **URL API** : <https://cloud.sycon.io>  
 **Spécification API 1.2.0** : `docs/v1.2.0/sycon-cloud-api`.    
 


### PR DESCRIPTION
**Quoi :** 
[Sycon Cloud API](https://hello-sycon.github.io/sycon-api/) le swagger deployé via github pages rajoute un Content-Type ‘application/x-www-form-urlencoded’ sur les requêtes partante, celui ci n’est pas pris en compte pas le backend.

**Analyse :** 
On reçoit un HttpMediaTypeNotSupportedException sur l’url '/auth/login'.

**Solution :** 
On change le lien vers le swagger pour celui de la production.